### PR TITLE
wesl-quote: use markers to define the injection type

### DIFF
--- a/crates/wesl-quote/README.md
+++ b/crates/wesl-quote/README.md
@@ -34,13 +34,17 @@ let wgsl = quote_module! {
 One can inject variables into the following places by prefixing the name with
 a `#` symbol:
 
-| Code location | Injected type | Indirectly supported injection type with `Into` |
-| ------------- | ------------- | ----------------------------------------------- |
-| name of a global declaration | `GlobalDeclaration` | `Declaration` `TypeAlias` `Struct` `Function` `ConstAssert` |
-| name of a struct member | `StructMember` | |
-| name of an attribute, after `@` | `Attribute` | `BuiltinValue` `InterpolateAttribute` `WorkgroupSizeAttribute` `TypeConstraint` `CustomAttribute` |
-| type or identifier expression | `Expression` | `LiteralExpression` `ParenthesizedExpression` `NamedComponentExpression` `IndexingExpression` `UnaryExpression` `BinaryExpression` `FunctionCallExpression` `TypeOrIdentifierExpression` and transitively: `bool` `i64` (AbstractInt) `f64` (AbstractFloat) `i32` `u32` `f32` `Ident` |
-| name of an attribute preceding and empty block statement | `Statement` | `CompoundStatement` `AssignmentStatement` `IncrementStatement` `DecrementStatement` `IfStatement` `SwitchStatement` `LoopStatement` `ForStatement` `WhileStatement` `BreakStatement` `ContinueStatement` `ReturnStatement` `DiscardStatement` `FunctionCallStatement` `ConstAssertStatement` `DeclarationStatement` |
+An interpolation is either a bare `#ident` (in expression position) or an explicit
+marker of the form `#marker@ident`. The marker selects the syntactic location to inject
+into:
+
+| Marker | Injected type | Indirectly supported injection type with `Into` |
+| ------ | ------------- | ----------------------------------------------- |
+| `#decl@ident` | `GlobalDeclaration` | `Declaration` `TypeAlias` `Struct` `Function` `ConstAssert` |
+| `#mem@ident` | `StructMember` | |
+| `#attr@ident` | `Attribute` | `BuiltinValue` `InterpolateAttribute` `WorkgroupSizeAttribute` `TypeConstraint` `CustomAttribute` |
+| `#expr@ident` or bare `#ident` | `Expression` | `LiteralExpression` `ParenthesizedExpression` `NamedComponentExpression` `IndexingExpression` `UnaryExpression` `BinaryExpression` `FunctionCallExpression` `TypeOrIdentifierExpression` and transitively: `bool` `i64` (AbstractInt) `f64` (AbstractFloat) `i32` `u32` `f32` `Ident` |
+| `#stmt@ident` | `Statement` | `CompoundStatement` `AssignmentStatement` `IncrementStatement` `DecrementStatement` `IfStatement` `SwitchStatement` `LoopStatement` `ForStatement` `WhileStatement` `BreakStatement` `ContinueStatement` `ReturnStatement` `DiscardStatement` `FunctionCallStatement` `ConstAssertStatement` `DeclarationStatement` |
 
 ```rust
 # use wesl_quote::quote_module;
@@ -51,11 +55,11 @@ let inject_func = Function::new(Ident::new("myfunc".to_string()));
 let inject_stmt = Statement::Void;
 let inject_expr = 1f32;
 let wgsl = quote_module! {
-    struct #inject_struct { dummy: u32 } // structs cannot be empty
-    fn #inject_func() {}
+    #decl@inject_struct
+    #decl@inject_func
     fn foo() {
-        @#inject_stmt {}
-        let x: f32 = #inject_expr;
+        #stmt@inject_stmt
+        let x: f32 = #expr@inject_expr;
     }
 };
 ```

--- a/crates/wesl-quote/src/quote_macro.rs
+++ b/crates/wesl-quote/src/quote_macro.rs
@@ -17,6 +17,8 @@ struct Lexer {
     recognizing_template: bool,
     opened_templates: u32,
     token_counter: usize,
+    /// Tokens produced by an interpolation marker (e.g. `#decl@ident`).
+    pending: std::collections::VecDeque<(Token, Span)>,
     extras: LexerState,
 }
 
@@ -269,17 +271,25 @@ impl Lexer {
             recognizing_template: false,
             opened_templates: 0,
             token_counter: 0,
+            pending: Default::default(),
             extras: Default::default(),
         };
         if lex.next_token.is_none() {
-            lex.next_token = lex
-                .rust_tok_next()
-                .and_then(|(tok, off)| lex.tok2wesl(tok, off));
+            lex.next_token = lex.wesl_next_token();
         }
         lex
     }
 
-    fn rust_tok_next(&mut self) -> Option<(RustToken, usize)> {
+    /// Pull the next WESL token, draining any pending interpolation tokens first.
+    fn wesl_next_token(&mut self) -> NextToken {
+        if let Some(tok) = self.pending.pop_front() {
+            return Some(tok);
+        }
+        self.rust_next_token()
+            .and_then(|(tok, off)| self.tok2wesl(tok, off))
+    }
+
+    fn rust_next_token(&mut self) -> Option<(RustToken, usize)> {
         let tok = self.token_stream.next()?;
         let offset = self.token_counter;
         self.token_counter += 1;
@@ -295,9 +305,7 @@ impl Lexer {
                 let (_, span) = tok1.as_ref().unwrap(); // safety: lookahead implies lexer looked at a `<` token
                 Some((tok, span.clone()))
             }
-            None => self
-                .rust_tok_next()
-                .and_then(|(tok, off)| self.tok2wesl(tok, off)),
+            None => self.wesl_next_token(),
         };
 
         (tok1, tok2)
@@ -318,12 +326,14 @@ impl Lexer {
             RustToken::Punct(punct) => {
                 let mut repr = punct.to_string();
                 if repr == "#" {
-                    match self.rust_tok_next()? {
-                        (RustToken::Ident(id), offset) => {
-                            span.end = offset + 1;
-                            Some((Token::Ident(format!("#{id}")), span))
+                    match self.rust_next_token()? {
+                        (RustToken::Ident(id), off) => {
+                            span.end = off + 1;
+                            self.marker2wesl(&id.to_string(), span)
                         }
-                        (tok, _) => abort!(tok.span(), "cannot escape token `{}`", tok),
+                        (tok, _) => {
+                            abort!(tok.span(), "expected an interpolation marker after `#`",)
+                        }
                     }
                 } else {
                     let mut join_punct = punct.spacing() == Spacing::Joint;
@@ -337,7 +347,7 @@ impl Lexer {
                                 } else {
                                     repr.push(chr);
                                     join_punct = punct.spacing() == Spacing::Joint;
-                                    let (_, offset) = self.rust_tok_next().unwrap();
+                                    let (_, offset) = self.rust_next_token().unwrap();
                                     span.end = offset + 1;
                                 }
                             }
@@ -348,6 +358,70 @@ impl Lexer {
                 }
             }
         }
+    }
+
+    /// Expand a variable interpolation composed of a marker and a variable identifier (e.g. `#expr@ident`).
+    fn marker2wesl(&mut self, marker: &str, mut span: Span) -> NextToken {
+        let is_marker = matches!(marker, "expr" | "decl" | "stmt" | "mem" | "attr")
+            && matches!(self.token_stream.peek(), Some(RustToken::Punct(p)) if p.as_char() == '@');
+
+        if !is_marker {
+            // no marker (#ident) is equivalent to #expr@ident.
+            return Some((Token::Ident(format!("#{marker}")), span));
+        }
+
+        self.rust_next_token(); // consume the `@`.
+
+        // consume the variable ident.
+        let (ident, off) = match self.rust_next_token() {
+            Some((RustToken::Ident(id), off)) => (id.to_string(), off),
+            Some((tok, _)) => abort!(tok.span(), "expected an identifier after `#{}@`", marker),
+            None => abort_call_site!("expected an identifier after `#{}@`", marker),
+        };
+        span.end = off + 1;
+
+        let inject = Token::Ident(format!("#{ident}"));
+
+        // build the token sequence for the marker. the first token is returned, the rest
+        // are queued in `self.pending`.
+        let (tok, pending): (Token, Vec<Token>) = match marker {
+            "expr" => {
+                // `#ident`
+                (inject, vec![])
+            }
+            "decl" | "stmt" => {
+                // `const #ident = __dummy_interpolation ;`
+                (
+                    Token::KwConst,
+                    vec![
+                        inject,
+                        Token::SymEqual,
+                        Token::Ident("__dummy_interpolation".to_string()),
+                        Token::SymSemicolon,
+                    ],
+                )
+            }
+            "mem" => {
+                // `#ident : __dummy_interpolation`
+                (
+                    inject,
+                    vec![
+                        Token::SymColon,
+                        Token::Ident("__dummy_interpolation".to_string()),
+                    ],
+                )
+            }
+            "attr" => {
+                // `@ #ident`
+                (Token::SymAttr, vec![inject])
+            }
+            _ => unreachable!("not a valid marker name"),
+        };
+
+        self.pending
+            .extend(pending.into_iter().map(|tok| (tok, span.clone())));
+
+        Some((tok, span))
     }
 
     fn next_tok(&mut self) -> Option<(Token, Span)> {

--- a/crates/wesl-quote/tests/interpolation.rs
+++ b/crates/wesl-quote/tests/interpolation.rs
@@ -1,0 +1,114 @@
+use wesl::syntax::*;
+use wesl_quote::quote_module;
+
+#[test]
+fn marker_injection() {
+    let inject_struct = Struct::new(Ident::new("mystruct".to_string()));
+    let inject_func = Function::new(Ident::new("myfunc".to_string()));
+    let inject_stmt = Statement::Void;
+    let inject_expr = 1f32;
+    let wgsl = quote_module! {
+        #decl@inject_struct
+        #decl@inject_func
+        fn foo() {
+            #stmt@inject_stmt
+            let x: f32 = #expr@inject_expr;
+        }
+    };
+
+    // two injected global decls + `fn foo`
+    assert_eq!(wgsl.global_declarations.len(), 3);
+
+    let names: Vec<_> = wgsl
+        .global_declarations
+        .iter()
+        .filter_map(|d| match d.node() {
+            GlobalDeclaration::Struct(s) => Some(s.ident.to_string()),
+            GlobalDeclaration::Function(f) => Some(f.ident.to_string()),
+            _ => None,
+        })
+        .collect();
+    assert!(names.contains(&"mystruct".to_string()));
+    assert!(names.contains(&"myfunc".to_string()));
+    assert!(names.contains(&"foo".to_string()));
+
+    // find `foo` and inspect its body
+    let foo = wgsl
+        .global_declarations
+        .iter()
+        .find_map(|d| match d.node() {
+            GlobalDeclaration::Function(f) if f.ident.to_string() == "foo" => Some(f),
+            _ => None,
+        })
+        .expect("foo not found");
+
+    // first statement is the injected `Statement::Void`
+    assert_eq!(foo.body.statements[0].node(), &Statement::Void);
+
+    // second statement declares `x` with initializer the injected literal `1f32`
+    match foo.body.statements[1].node() {
+        Statement::Declaration(decl) => {
+            assert_eq!(decl.ident.to_string(), "x");
+            let init = decl.initializer.as_ref().unwrap();
+            assert_eq!(
+                init.node(),
+                &Expression::Literal(LiteralExpression::F32(1.0))
+            );
+        }
+        s => panic!("unexpected statement: {s:?}"),
+    }
+}
+
+#[test]
+fn bare_ident_injection() {
+    let ty = Ident::new("u32".to_string());
+    let wgsl = quote_module! {
+        struct S { field: #ty }
+    };
+    assert_eq!(wgsl.global_declarations.len(), 1);
+}
+
+#[test]
+fn mem_and_attr_markers() {
+    let inject_mem = StructMember {
+        attributes: Vec::new(),
+        ident: Ident::new("injected_field".to_string()),
+        ty: TypeExpression::from(Ident::new("u32".to_string())),
+    };
+    let inject_attr = Attribute::Custom(CustomAttribute {
+        name: "myattr".to_string(),
+        arguments: None,
+    });
+
+    let wgsl = quote_module! {
+        struct S {
+            #mem@inject_mem,
+            other: f32,
+        }
+        #attr@inject_attr
+        fn foo() {}
+    };
+
+    let s = wgsl
+        .global_declarations
+        .iter()
+        .find_map(|d| match d.node() {
+            GlobalDeclaration::Struct(s) => Some(s),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(s.members[0].ident.to_string(), "injected_field");
+
+    let foo = wgsl
+        .global_declarations
+        .iter()
+        .find_map(|d| match d.node() {
+            GlobalDeclaration::Function(f) => Some(f),
+            _ => None,
+        })
+        .unwrap();
+    match foo.attributes[0].node() {
+        Attribute::Custom(a) => assert_eq!(a.name, "myattr"),
+        a => panic!("unexpected attr: {a:?}"),
+    }
+}

--- a/crates/wgsl-parse/src/tokrepr.rs
+++ b/crates/wgsl-parse/src/tokrepr.rs
@@ -47,15 +47,11 @@ impl NamedNode for Expression {
 
 impl NamedNode for Statement {
     fn name(&self) -> Option<String> {
-        // COMBAK: this nesting is hell. Hopefully if-let chains will stabilize soon.
-        if let Statement::Compound(stmt) = self
-            && stmt.statements.is_empty()
-            && let [attr] = stmt.attributes.as_slice()
-            && let Attribute::Custom(attr) = attr.node()
-        {
-            return Some(attr.name.to_string());
+        if let Statement::Declaration(stmt) = self {
+            Some(stmt.ident.to_string())
+        } else {
+            None
         }
-        None
     }
 }
 


### PR DESCRIPTION
fixed #186

Variable interpolations can now be prefixed with `type@` marker, where `type` is one of `decl`, `stmt`, `mem`, `attr`, or `expr`. The marker wraps the injection in a dummy AST node of the corresponding type. After parsing, the dummy node is replaced with the injection variable as was the case before. 

The old way still works, so it's still a bit quirky to have "dummy nodes", but I don't see a better solution.

Before:
```rust
use wesl::syntax::*; // this is necessary for the quote_module macro

let inject_struct = Struct::new(Ident::new("mystruct".to_string()));
let inject_func = Function::new(Ident::new("myfunc".to_string()));
let inject_stmt = Statement::Void;
let inject_expr = 1f32;
let wgsl = quote_module! {
    struct #inject_struct { dummy: u32 } // structs cannot be empty
    fn #inject_func() {}
    fn foo() {
        @#inject_stmt {}
        let x: f32 = #inject_expr;
    }
};
```

After:
```rust
use wesl::syntax::*; // this is necessary for the quote_module macro

let inject_struct = Struct::new(Ident::new("mystruct".to_string()));
let inject_func = Function::new(Ident::new("myfunc".to_string()));
let inject_stmt = Statement::Void;
let inject_expr = 1f32;
let wgsl = quote_module! {
    #decl@inject_struct
    #decl@inject_func
    fn foo() {
        #stmt@inject_stmt
        let x: f32 = #inject_expr; // or #expr@inject_expr
    }
};
```