### PR TITLE
support linear algebra matrix-column-vector product

### DIFF
--- a/crates/wgsl-types/src/builtin/ops_ty.rs
+++ b/crates/wgsl-types/src/builtin/ops_ty.rs
@@ -157,25 +157,29 @@ impl Type {
                 let ty = convert_ty(self, rhs).ok_or_else(err)?;
                 Ok(ty.clone())
             }
+            // component-wise scaling
             (scalar_ty, Type::Vec(n, vec_ty)) | (Type::Vec(n, vec_ty), scalar_ty)
                 if scalar_ty.is_scalar() =>
             {
                 let inner_ty = convert_ty(scalar_ty, vec_ty).ok_or_else(err)?;
                 Ok(Type::Vec(*n, Box::new(inner_ty.clone())))
             }
+            // component-wise scaling
             (scalar_ty, Type::Mat(c, r, mat_ty)) | (Type::Mat(c, r, mat_ty), scalar_ty)
                 if scalar_ty.is_scalar() =>
             {
                 let inner_ty = convert_ty(scalar_ty, mat_ty).ok_or_else(err)?;
                 Ok(Type::Mat(*c, *r, Box::new(inner_ty.clone())))
             }
-            (Type::Vec(n1, vec_ty), Type::Mat(n2, n, mat_ty))
-            | (Type::Mat(n, n1, mat_ty), Type::Vec(n2, vec_ty))
-                if n1 == n2 =>
-            {
+            // linear algebra row-vector-matrix product
+            (Type::Vec(n1, vec_ty), Type::Mat(n, n2, mat_ty))
+            // linear algebra matrix-column-vector product
+            | (Type::Mat(n1, n, mat_ty), Type::Vec(n2, vec_ty))
+             if n1 == n2 => {
                 let inner_ty = convert_ty(vec_ty, mat_ty).ok_or_else(err)?;
                 Ok(Type::Vec(*n, Box::new(inner_ty.clone())))
             }
+            // linear algebra matrix product
             (Type::Mat(k1, r, lhs), Type::Mat(c, k2, rhs)) if k1 == k2 => {
                 let inner_ty = convert_ty(lhs, rhs).ok_or_else(err)?;
                 Ok(Type::Mat(*c, *r, Box::new(inner_ty.clone())))


### PR DESCRIPTION
caught in wgsl-analyzer while looking at bevy code
```rs
let world_position = mat3x4(world_position_0, world_position_1, world_position_2) * partial_derivatives.barycentrics;
```
```rs
#[test]
fn mat_times_vec() {
    check_diagnostics(
        "
fn foo() {
    let x = mat3x4f(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
    let y = vec3f(1, 2, 3);
    let z = x * y;
}
        ",
        expect![[r#"
            111..116 wesl-rs Error 22: cannot use binary operator `*` with operands `mat3x4<f32>` and `vec3<f32>`
        "#]],
    );
}
```