### PR TITLE
Parse/validate acceleration_structure tags

### DIFF
--- a/crates/wesl/src/eval/to_expr.rs
+++ b/crates/wesl/src/eval/to_expr.rs
@@ -286,20 +286,25 @@ impl ToExpr for Type {
             Type::Sampler(_) => Ok(TypeExpression::new(ident.unwrap())),
             Type::Unknown => Err(E::NotConstructible(Type::Unknown)),
             #[cfg(feature = "naga-ext")]
-            Type::RayQuery(flags) | Type::AccelerationStructure(flags) => Ok(TypeExpression {
-                path: None,
-                ident: ident.unwrap(),
-                template_args: (*flags == Some(AccelerationStructureFlags::VertexReturn)).then(
-                    || {
-                        vec![TemplateArg {
-                            expression: Expression::TypeOrIdentifier(TypeExpression::new(
-                                builtin_ident("vertex_return").unwrap().clone(),
-                            ))
-                            .into(),
-                        }]
-                    },
-                ),
-            }),
+            Type::RayQuery(template) | Type::AccelerationStructure(template) => {
+                Ok(TypeExpression {
+                    path: None,
+                    ident: ident.unwrap(),
+                    template_args: template.as_ref().map(|tags| {
+                        tags.tags()
+                            .iter()
+                            .map(|tag| match tag {
+                                AccelerationStructureTag::VertexReturn => TemplateArg {
+                                    expression: Expression::TypeOrIdentifier(TypeExpression::new(
+                                        builtin_ident("vertex_return").unwrap().clone(),
+                                    ))
+                                    .into(),
+                                },
+                            })
+                            .collect()
+                    }),
+                })
+            }
         }
         .map(Expression::from)
     }

--- a/crates/wgsl-types/src/builtin/mod.rs
+++ b/crates/wgsl-types/src/builtin/mod.rs
@@ -34,6 +34,8 @@ pub(crate) use ops::Compwise;
 
 use itertools::Itertools;
 
+#[cfg(feature = "naga-ext")]
+use crate::tplt::AccelerationStructureTags;
 use crate::{
     CallSignature, Error, Instance, ShaderStage,
     syntax::{BinaryOperator, UnaryOperator},
@@ -385,8 +387,9 @@ pub fn builtin_type(name: &str, tplt: Option<&[TpltParam]>) -> Result<Type, E> {
             #[cfg(feature = "naga-ext")]
             "ray_query" => Ok(Type::RayQuery(None)),
             #[cfg(feature = "naga-ext")]
+            // requires enable extensions
             "acceleration_structure" => Ok(Type::AccelerationStructure(Some(
-                crate::syntax::AccelerationStructureFlags::VertexReturn,
+                AccelerationStructureTags::parse(t)?,
             ))),
 
             _ => Err(E::UnexpectedTemplate(name.to_string())),

--- a/crates/wgsl-types/src/display.rs
+++ b/crates/wgsl-types/src/display.rs
@@ -116,7 +116,7 @@ impl Display for Enumerant {
             Enumerant::AddressSpace(address_space) => write!(f, "{address_space}"),
             Enumerant::TexelFormat(texel_format) => write!(f, "{texel_format}"),
             #[cfg(feature = "naga-ext")]
-            Enumerant::AccelerationStructureFlags(flags) => write!(f, "{flags}"),
+            Enumerant::AccelerationStructureTag(tag) => write!(f, "{tag}"),
         }
     }
 }

--- a/crates/wgsl-types/src/syntax.rs
+++ b/crates/wgsl-types/src/syntax.rs
@@ -140,7 +140,7 @@ pub enum TexelFormat {
 #[cfg_attr(feature = "tokrepr", derive(TokRepr))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum AccelerationStructureFlags {
+pub enum AccelerationStructureTag {
     VertexReturn,
 }
 
@@ -153,7 +153,7 @@ pub enum Enumerant {
     AddressSpace(AddressSpace),
     TexelFormat(TexelFormat),
     #[cfg(feature = "naga-ext")]
-    AccelerationStructureFlags(AccelerationStructureFlags),
+    AccelerationStructureTag(AccelerationStructureTag),
 }
 
 impl FromStr for Enumerant {
@@ -166,7 +166,7 @@ impl FromStr for Enumerant {
             .or_else(|()| TexelFormat::from_str(s).map(Enumerant::TexelFormat));
         #[cfg(feature = "naga-ext")]
         let res = res.or_else(|()| {
-            AccelerationStructureFlags::from_str(s).map(Enumerant::AccelerationStructureFlags)
+            AccelerationStructureTag::from_str(s).map(Enumerant::AccelerationStructureTag)
         });
         res
     }
@@ -663,7 +663,7 @@ impl FromStr for TexelFormat {
 }
 
 #[cfg(feature = "naga-ext")]
-impl FromStr for AccelerationStructureFlags {
+impl FromStr for AccelerationStructureTag {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -899,7 +899,7 @@ impl Display for TexelFormat {
 }
 
 #[cfg(feature = "naga-ext")]
-impl Display for AccelerationStructureFlags {
+impl Display for AccelerationStructureTag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::VertexReturn => write!(f, "vertex_return"),

--- a/crates/wgsl-types/src/tplt.rs
+++ b/crates/wgsl-types/src/tplt.rs
@@ -1,5 +1,7 @@
 //! Built-in type-generator and function templates.
 
+#[cfg(feature = "naga-ext")]
+use crate::syntax::AccelerationStructureTag;
 use crate::{
     Error,
     inst::{Instance, LiteralInstance},
@@ -347,5 +349,35 @@ impl BitcastTemplate {
     }
     pub fn inner_ty(&self) -> Type {
         self.ty.inner_ty()
+    }
+}
+
+#[cfg(feature = "naga-ext")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccelerationStructureTags {
+    tags: Vec<AccelerationStructureTag>,
+}
+
+#[cfg(feature = "naga-ext")]
+impl AccelerationStructureTags {
+    pub fn parse(tplt: &[TpltParam]) -> Result<Self, E> {
+        let tags = tplt
+            .iter()
+            .map(|param| match param {
+                TpltParam::Enumerant(Enumerant::AccelerationStructureTag(tag)) => Ok(*tag),
+                TpltParam::Instance(_) => Err(Error::Builtin(
+                    "expected an acceleration structure tag, not an instance",
+                )),
+                TpltParam::Type(_) => Err(Error::Builtin(
+                    "expected an acceleration structure tag, not a type",
+                )),
+                _ => Err(Error::Builtin("unknown acceleration structure tag")),
+            })
+            .collect::<Result<Vec<_>, E>>()?;
+        Ok(Self { tags })
+    }
+
+    pub fn tags(&self) -> &[AccelerationStructureTag] {
+        &self.tags
     }
 }

--- a/crates/wgsl-types/src/ty.rs
+++ b/crates/wgsl-types/src/ty.rs
@@ -2,6 +2,8 @@
 
 use std::str::FromStr;
 
+#[cfg(feature = "naga-ext")]
+use crate::tplt::AccelerationStructureTags;
 use crate::{Error, Instance, inst::*, syntax::*};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -291,9 +293,9 @@ pub enum Type {
     #[cfg(feature = "naga-ext")]
     BindingArray(Box<Type>, Option<usize>),
     #[cfg(feature = "naga-ext")]
-    RayQuery(Option<AccelerationStructureFlags>),
+    RayQuery(Option<AccelerationStructureTags>),
     #[cfg(feature = "naga-ext")]
-    AccelerationStructure(Option<AccelerationStructureFlags>),
+    AccelerationStructure(Option<AccelerationStructureTags>),
 }
 
 impl Type {


### PR DESCRIPTION
At the moment, it just assumes that if there is a template, then it is the specific, only valid template. Now, this does full parsing and error handling.

not technically blocking for bevy since they don't use tags, but we probably want this so that they get red squiggles for invalid templates