### PR TITLE
export `half::f16` because it is in `pub LiteralInstance`

### DIFF
--- a/crates/wesl/src/eval/eval.rs
+++ b/crates/wesl/src/eval/eval.rs
@@ -1,6 +1,6 @@
-use half::f16;
 use itertools::Itertools;
 use wgsl_parse::{span::Spanned, syntax::*};
+use wgsl_types::f16;
 use wgsl_types::{
     builtin::{call_binary_op, call_unary_op},
     inst::{Instance, LiteralInstance, RefInstance, VecInstance},

--- a/crates/wesl/src/eval/eval.rs
+++ b/crates/wesl/src/eval/eval.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use wgsl_parse::{span::Spanned, syntax::*};
-use wgsl_types::f16;
 use wgsl_types::{
     builtin::{call_binary_op, call_unary_op},
+    f16,
     inst::{Instance, LiteralInstance, RefInstance, VecInstance},
     ty::{Ty, Type},
 };

--- a/crates/wgsl-types/src/builtin/call.rs
+++ b/crates/wgsl-types/src/builtin/call.rs
@@ -16,7 +16,7 @@
 
 #![allow(non_snake_case)]
 
-use half::prelude::*;
+use half::f16;
 use itertools::{Itertools, chain, izip};
 use num_traits::{One, ToBytes, ToPrimitive, Zero, real::Real};
 

--- a/crates/wgsl-types/src/builtin/call.rs
+++ b/crates/wgsl-types/src/builtin/call.rs
@@ -16,13 +16,13 @@
 
 #![allow(non_snake_case)]
 
-use half::f16;
 use itertools::{Itertools, chain, izip};
 use num_traits::{One, ToBytes, ToPrimitive, Zero, real::Real};
 
 use crate::{
     Error, Instance, ShaderStage,
     conv::{Convert, convert, convert_all_ty},
+    f16,
     inst::{
         AtomicInstance, LiteralInstance, MatInstance, RefInstance, StructInstance, VecInstance,
     },

--- a/crates/wgsl-types/src/builtin/ctor.rs
+++ b/crates/wgsl-types/src/builtin/ctor.rs
@@ -11,7 +11,7 @@
 //! * User-defined functions can shadow WGSL built-in functions.
 //! * Type aliases must be resolved: WGSL allows calling functions with the name of the alias.
 
-use half::prelude::*;
+use half::f16;
 use itertools::Itertools;
 use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
 

--- a/crates/wgsl-types/src/builtin/ctor.rs
+++ b/crates/wgsl-types/src/builtin/ctor.rs
@@ -11,13 +11,13 @@
 //! * User-defined functions can shadow WGSL built-in functions.
 //! * Type aliases must be resolved: WGSL allows calling functions with the name of the alias.
 
-use half::f16;
 use itertools::Itertools;
 use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
 
 use crate::{
     CallSignature, Error, ShaderStage,
     conv::{Convert, convert_all, convert_all_inner_to, convert_all_to, convert_all_ty},
+    f16,
     inst::{ArrayInstance, Instance, LiteralInstance, MatInstance, StructInstance, VecInstance},
     tplt::{ArrayTemplate, MatTemplate, TpltParam, VecTemplate},
     ty::{StructType, Ty, Type},

--- a/crates/wgsl-types/src/conv.rs
+++ b/crates/wgsl-types/src/conv.rs
@@ -5,12 +5,11 @@
 //!
 //! [automatic conversions]: https://www.w3.org/TR/WGSL/#feasible-automatic-conversion
 
-use half::f16;
 use itertools::Itertools;
 use num_traits::{FromPrimitive, ToPrimitive};
 
 use crate::{
-    Error, Instance,
+    Error, Instance, f16,
     inst::{ArrayInstance, LiteralInstance, MatInstance, StructInstance, VecInstance},
     syntax::AccessMode,
     ty::{Ty, Type},

--- a/crates/wgsl-types/src/inst.rs
+++ b/crates/wgsl-types/src/inst.rs
@@ -6,11 +6,10 @@ use std::{
     rc::Rc,
 };
 
-use half::f16;
 use itertools::Itertools;
 
 use crate::{
-    Error,
+    Error, f16,
     syntax::{AccessMode, AddressSpace},
     ty::{StructType, Ty, Type},
 };

--- a/crates/wgsl-types/src/lib.rs
+++ b/crates/wgsl-types/src/lib.rs
@@ -17,6 +17,8 @@ pub use error::Error;
 pub use inst::Instance;
 pub use ty::Type;
 
+pub use half::f16;
+
 use tplt::TpltParam;
 
 /// Function call signature.

--- a/crates/wgsl-types/src/mem.rs
+++ b/crates/wgsl-types/src/mem.rs
@@ -1,9 +1,9 @@
 //! Memory layout utilities.
 
-use half::f16;
 use itertools::Itertools;
 
 use crate::{
+    f16,
     inst::{
         ArrayInstance, AtomicInstance, Instance, LiteralInstance, MatInstance, StructInstance,
         VecInstance,


### PR DESCRIPTION
also made it clear that it is the only one used
```sh
 benjamin@pop-os  ~/source/wesl-rs   export-f16  rg 'half::'
crates/wgsl-types/src/lib.rs
20:pub use half::f16;
```