### PR TITLE
Improve compile times by using type erasure + a worrying look into the future of rustc

### DIFF
--- a/crates/wesl-macros/src/query_macro.rs
+++ b/crates/wesl-macros/src/query_macro.rs
@@ -153,10 +153,12 @@ pub(crate) fn query_impl(input: QueryInput, mutable: bool) -> TokenStream {
                                 let iter = std::iter::Iterator::chain(iter, #first #(.#rest)*);
                             })
                         });
-                    quote! { flat_map(|x| {
+                    // Keep large query branches behind a trait object. Without this, every
+                    // `Iterator::chain` becomes part of the concrete return type of `query!`.
+                    quote! { flat_map(|x| -> Box<dyn Iterator<Item = _>> {
                         let iter = std::iter::empty();
                         #(#cases)*
-                        iter
+                        Box::new(iter)
                     }) }
                 }
             },


### PR DESCRIPTION
While playing around with rustc's [upcoming new trait solver](https://github.com/rust-lang/goals/issues/113) on [bevy](https://github.com/bevyengine/bevy) , I noticed that it improved the performance of some of Bevy's subcrates, but the total compilation time was much worse due to `wesl`.

Turns out that `wesl` interacts surprisingly bad with this new solver. I was able to find very simple patch that improves this a bunch, as well as improves the compile times under the legacy solver:

| Solver | `naga-ext` | Version | Total | Frontend | Codegen |
| --- | --- | --- | ---: | ---: | ---: |
| Current solver | enabled | Before | 6.7s | 4.6s | 2.1s |
| Current solver | enabled | After | 5.0s | 2.6s | 2.3s |
| Next solver | enabled | Before | 164.4s | 161.5s | 2.9s |
| Next solver | enabled | After | 43.0s | 40.5s | 2.5s |

A critical read might say that the next solver is still a major performance setback when it comes to this crate. And they would be right! I will also report this regression upstream ([DONE HERE](https://github.com/rust-lang/rust/issues/161625)) at rustc in the hope that they can use `wesl` as a case study before rolling out the new solver as the default.

## Tradeoffs

I believe that these boxes do incur a slight runtime cost due to dynamic dispatch. Under the legacy solver, this patch not an extremely convincing win.

## Benchmark command

Timings were collected from clean target directories using Cargo's timing
report. The new-solver measurement used a locally built nightly/dev compiler
that supports `-Znext-solver`.

```sh
# Current solver, with `naga-ext`
CARGO_TARGET_DIR=<checkout>  \
  cargo build -p wesl --features naga-ext --timings

# Experimental next-generation solver, with `naga-ext`
RUSTFLAGS='-Znext-solver=globally' \
  CARGO_TARGET_DIR=<checkout> \
  cargo build -p wesl --features naga-ext --timings
```

### So what's next?

Not sure, tbh. I just wanted to get this out there.