### PR TITLE
Don't mangle or strip overrides

### DIFF
--- a/crates/wesl-test/spec-tests/overrides.json
+++ b/crates/wesl-test/spec-tests/overrides.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "keep-override-name-in-imported-module",
+        "weslSrc": {
+            "./main.wgsl": "import package::m1::taps; fn main() { let t = taps(); }",
+            "./m1.wgsl": "override TAPS: u32 = 4u; fn taps() -> u32 { return TAPS; }"
+        },
+        "expectedWgsl": "fn main() { let t = taps(); } override TAPS: u32 = 4u; fn taps() -> u32 { return TAPS; }",
+        "underscoreWgsl": "fn main() { let t = package_m1_taps(); } override TAPS: u32 = 4u; fn package_m1_taps() -> u32 { return TAPS; }"
+    },
+    {
+        "name": "keep-unused-override",
+        "weslSrc": {
+            "./main.wgsl": "import package::m1::foo; fn main() { foo(); }",
+            "./m1.wgsl": "const BASE: u32 = 2u; override UNUSED: u32 = BASE; fn foo() { } fn bar() { }"
+        },
+        "expectedWgsl": "fn main() { foo(); } const BASE: u32 = 2u; override UNUSED: u32 = BASE; fn foo() { }",
+        "underscoreWgsl": "fn main() { package_m1_foo(); } const package_m1_BASE: u32 = 2u; override UNUSED: u32 = package_m1_BASE; fn package_m1_foo() { }"
+    }
+]

--- a/crates/wesl-test/tests/snapshots/testsuite__wgpu__in__overrides.snap
+++ b/crates/wesl-test/tests/snapshots/testsuite__wgpu__in__overrides.snap
@@ -2,6 +2,8 @@
 source: crates/wesl-test/tests/testsuite.rs
 expression: res.syntax.to_string()
 ---
+override auto_conversion: u32 = 0;
+
 override depth: f32;
 
 @id(1300)
@@ -11,6 +13,13 @@ override gain: f32;
 override has_point_light: bool = true;
 
 override height: f32 = 2 * depth;
+
+override inferred_f32: f32 = 2.718;
+
+@id(1200)
+override specular_param: f32 = 2.3;
+
+override width: f32 = 0.0;
 
 var<private> gain_x_10: f32 = gain * 10.0;
 

--- a/crates/wesl-test/tests/testsuite.rs
+++ b/crates/wesl-test/tests/testsuite.rs
@@ -115,6 +115,7 @@ fn main() {
         "wesl-testsuite/src/test-cases-json/conditionalTranslationCases.json",
         "spec-tests/dead-code.json",
         "spec-tests/condcomp-flatten.json",
+        "spec-tests/overrides.json",
     ];
     for path in testsuite_tests {
         tests.extend({

--- a/crates/wesl/src/frontend.rs
+++ b/crates/wesl/src/frontend.rs
@@ -633,6 +633,16 @@ impl CompilerDriver for CompilationPass<'_> {
 
         let mut module = pass::link(modules, self.options.strip.then_some(used_items));
 
+        let mut host_visible = HashSet::new();
+        for decl in &module.global_declarations {
+            if pass::is_host_visible(decl)
+                && let Some(ident) = decl.ident()
+                && !host_visible.insert(ident.name().to_string())
+            {
+                return Err(ImportError::DuplicateSymbol(ident.name().to_string()).into());
+            }
+        }
+
         if self.options.lower {
             pass::lower(&mut module)?;
         }
@@ -649,4 +659,34 @@ impl CompilerDriver for CompilationPass<'_> {
 fn test_send_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<Compiler<()>>();
+}
+
+#[test]
+fn duplicate_override_across_modules() {
+    let mut resolver = crate::resolver::VirtualResolver::new();
+    resolver.add_module(
+        "package::a".parse().unwrap(),
+        "override X: u32 = 1u; fn a() -> u32 { return X; }".into(),
+    );
+    resolver.add_module(
+        "package::b".parse().unwrap(),
+        "override X: u32 = 2u; fn b() -> u32 { return X; }".into(),
+    );
+    resolver.add_module(
+        "package::main".parse().unwrap(),
+        "import package::{a::a, b::b}; fn main() -> u32 { return a() + b(); }".into(),
+    );
+    let options = CompileOptions {
+        keep_main: true,
+        ..Default::default()
+    };
+    let result = Compiler::new_with_resolver(options, resolver)
+        .compile_module(&"package::main".parse().unwrap());
+    match result {
+        Err(err) => assert!(
+            err.to_string().contains("duplicate declaration of `X`"),
+            "{err}"
+        ),
+        Ok(_) => panic!("expected a duplicate declaration error"),
+    }
 }

--- a/crates/wesl/src/pass/mangle.rs
+++ b/crates/wesl/src/pass/mangle.rs
@@ -1,17 +1,32 @@
 use wgsl_parse::{
     SyntaxNode,
-    syntax::{ModulePath, TranslationUnit},
+    syntax::{
+        DeclarationKind, GlobalDeclaration, GlobalDeclarationNode, ModulePath, TranslationUnit,
+    },
 };
 
 use crate::mangler::Mangler;
 
-/// Mangle all declarations in all modules. Should be called after `retarget_idents`.
+/// Whether a declaration is host-visible: the host refers to it by name in the compiled
+/// WGSL, so it must be neither mangled nor stripped. Currently, only pipeline-overridable
+/// constants.
+pub fn is_host_visible(decl: &GlobalDeclarationNode) -> bool {
+    matches!(
+        decl.node(),
+        GlobalDeclaration::Declaration(decl) if decl.kind == DeclarationKind::Override
+    )
+}
+
+/// Mangle all declarations in a module except host-visible ones.
+///
+/// Should be called after `retarget_idents`.
 ///
 /// Panics if a module is already borrowed.
 pub fn mangle(module: &mut TranslationUnit, path: &ModulePath, mangler: &impl Mangler) {
     module
         .global_declarations
         .iter_mut()
+        .filter(|decl| !is_host_visible(decl))
         .filter_map(|decl| decl.ident())
         .for_each(|mut ident| {
             let new_name = mangler.mangle(path, &ident.name());

--- a/crates/wesl/src/pass/mod.rs
+++ b/crates/wesl/src/pass/mod.rs
@@ -18,7 +18,7 @@ pub use driver::{CompileResult, CompilerDriver};
 pub use import::{ImportedItem, Imports, flatten_imports, imported_item_path};
 pub use link::link;
 pub use lower::lower;
-pub use mangle::mangle;
+pub use mangle::{is_host_visible, mangle};
 pub use retarget_idents::{retarget_idents, retarget_modules};
 pub use usage_analysis::{Module, UsedItems, module_usage_analysis, usage_analysis};
 pub use validate::{validate_wesl, validate_wgsl};

--- a/crates/wesl/src/pass/usage_analysis.rs
+++ b/crates/wesl/src/pass/usage_analysis.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet, hash_map::Entry};
 use wgsl_parse::{SyntaxNode, syntax::*};
 
-use crate::pass::{Imports, Visit, flatten_imports, imported_item_path};
+use crate::pass::{Imports, Visit, flatten_imports, imported_item_path, is_host_visible};
 
 #[derive(Clone)]
 pub struct Module {
@@ -103,7 +103,8 @@ impl UsedItems {
 
 /// Find declarations used in external modules which this module depends on, no matter what.
 ///
-/// Currently, only items referenced by module-scope `const_assert`s are always included.
+/// Currently, items referenced by module-scope `const_assert`s and by host-visible
+/// declarations are always included.
 ///
 /// See [`usage_analysis`].
 pub fn module_usage_analysis(
@@ -116,13 +117,13 @@ pub fn module_usage_analysis(
     }
 
     already_used.insert_module(module.path.clone(), Default::default());
-    let const_asserts = module
+    let always_included = module
         .syntax
         .global_declarations
         .iter()
-        .filter(|decl| decl.is_const_assert());
+        .filter(|decl| decl.is_const_assert() || is_host_visible(decl));
 
-    for decl in const_asserts {
+    for decl in always_included {
         decl_usage_analysis(module, decl, already_used, to_analyze);
     }
 }

--- a/crates/wesl/tests/snapshots/frontend__compile_wesl_toml_feat1.snap
+++ b/crates/wesl/tests/snapshots/frontend__compile_wesl_toml_feat1.snap
@@ -18,9 +18,9 @@ const package_util__1INTERNAL_SCALE: f32 = 2.0;
 
 const package_util_ops__1OPS_BASE: f32 = 4.0;
 
-override package_gfx_exposure: f32 = 1.0;
+override exposure: f32 = 1.0;
 
-override package_gfx_gain: f32 = package_gfx_exposure * 2.0;
+override gain: f32 = exposure * 2.0;
 
 override root_boost: f32 = 1.0;
 
@@ -103,7 +103,7 @@ fn package__1cycle_b_pong(x: f32) -> f32 {
 }
 
 fn package_gfx_tonemap(c: vec2f) -> f32 {
-    return package_util_cross2(c, vec2f(package_util_EPSILON)) * package_gfx_gain;
+    return package_util_cross2(c, vec2f(package_util_EPSILON)) * gain;
 }
 
 fn package_legacy__1legacy_fn(x: f32) -> f32 {

--- a/crates/wesl/tests/snapshots/frontend__compile_wesl_toml_feat2.snap
+++ b/crates/wesl/tests/snapshots/frontend__compile_wesl_toml_feat2.snap
@@ -20,9 +20,9 @@ const package_util__1INTERNAL_SCALE: f32 = 2.0;
 
 const package_util_ops__1OPS_BASE: f32 = 4.0;
 
-override package_gfx_exposure: f32 = 1.0;
+override exposure: f32 = 1.0;
 
-override package_gfx_gain: f32 = package_gfx_exposure * 2.0;
+override gain: f32 = exposure * 2.0;
 
 override root_boost: f32 = 2.0;
 
@@ -111,7 +111,7 @@ fn package__1cycle_b_pong(x: f32) -> f32 {
 }
 
 fn package_gfx_tonemap(c: vec2f) -> f32 {
-    return package_util_cross2(c, vec2f(package_util_EPSILON)) * package_gfx_gain;
+    return package_util_cross2(c, vec2f(package_util_EPSILON)) * gain;
 }
 
 fn package_legacy__1legacy_fn(x: f32) -> f32 {

--- a/crates/wesl/tests/snapshots/frontend__compile_wgsl_strip.snap
+++ b/crates/wesl/tests/snapshots/frontend__compile_wgsl_strip.snap
@@ -12,6 +12,13 @@ const c1 = 1;
 
 const c2: u32 = 2;
 
+override o1: f32;
+
+override o2 = 0;
+
+@id(10)
+override o3: u32 = 0;
+
 const_assert (c1 < c2);
 
 const_assert c1 == 1;


### PR DESCRIPTION
Prototype for the override mangling discussion on Bevy's Discord.

An override declared in an imported module gets a mangled name, so the host can't set it without knowing the mangler's output. Per the Discord discussion, this changes it so overrides are never mangled, and two modules declaring the same override name is a link error.

It also treats overrides as usage-analysis roots so stripping never removes them. That lets a host set a value for an override that the shader may or may not reference (naga rejects a pipeline constant with no matching override in the module).

The `uninitialized override` case in wesl-testsuite expects the mangled name in its `underscoreWgsl` and now fails.